### PR TITLE
Pass config file in the form for addstore

### DIFF
--- a/core/store/src/main/java/mil/nga/giat/geowave/core/store/operations/config/AddStoreCommand.java
+++ b/core/store/src/main/java/mil/nga/giat/geowave/core/store/operations/config/AddStoreCommand.java
@@ -149,11 +149,12 @@ public class AddStoreCommand extends
 				existingProps);
 	}
 
-	@Post("json")
+	@Post("form:json")
 	public void restPost(
 			Representation entity ) {
 
-		Form form = new Form(entity);
+		Form form = new Form(
+				entity);
 		String name = form.getFirstValue("name");
 
 		// String name = getQueryValue("name");
@@ -171,10 +172,14 @@ public class AddStoreCommand extends
 				name,
 				new MemoryStoreFactoryFamily());
 
+		String configFileParameter = form.getFirstValue("config_file");
+		File configFile = (configFileParameter != null) ? new File(
+				configFileParameter) : ConfigOptions.getDefaultPropertyFile();
+
 		OperationParams params = new ManualOperationParams();
 		params.getContext().put(
 				ConfigOptions.PROPERTIES_FILE_CONTEXT,
-				ConfigOptions.getDefaultPropertyFile());
+				configFile);
 
 		prepare(params);
 		final MemoryRequiredOptions opts = (MemoryRequiredOptions) pluginOptions.getFactoryOptions();

--- a/services/rest/src/test/java/mil/nga/giat/geowave/service/rest/RestServerTest.java
+++ b/services/rest/src/test/java/mil/nga/giat/geowave/service/rest/RestServerTest.java
@@ -11,7 +11,9 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.shaded.restlet.Context;
 import org.restlet.ext.json.JsonRepresentation;
 import org.shaded.restlet.resource.ResourceException;
@@ -34,6 +36,9 @@ import java.util.Properties;
 
 public class RestServerTest
 {
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
 	@BeforeClass
 	public static void runServer() {
 		RestServer.main(new String[] {});
@@ -119,14 +124,20 @@ public class RestServerTest
 
 	// Tests geowave/config/addstore
 	@Test
-	public void geowave_config_addstore() {
+	public void geowave_config_addstore()
+			throws IOException {
 		ClientResource resource = new ClientResource(
 				"http://localhost:5152/geowave/config/addstore");
+
+		File configFile = tempFolder.newFile("test_config");
 
 		Form form = new Form();
 		form.add(
 				"name",
 				"memory");
+		form.add(
+				"config_file",
+				configFile.getAbsolutePath());
 		try {
 
 			resource.post(


### PR DESCRIPTION
Here's an easy way to do it.
ConfigCacheIT uses a test_config file (line 73). W we can force the same behavior when it is running in test mode by passing a config file in the form. I've done that for addstore but we'll need the same for the others as well. Fortunately, one's Joe's change is in that makes the rest endpoint automatic, this will only need to be in one place.